### PR TITLE
Support for XCode 8+ feature PROVISIONING_PROFILE_SPECIFIER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,7 @@ xcuserdata/
 *.xcscmblueprint
 *.xccheckout
 *.xcodeproj/*
+!misc/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
 
 ##############################
 ### Visual Studio specific ###

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@
 				MARKETING_VERSION = $short_version;
 				CURRENT_PROJECT_VERSION = $version;
 				PROVISIONING_PROFILE = "$provisioning_profile_uuid_debug";
+				PROVISIONING_PROFILE_SPECIFIER = "$provisioning_profile_specifier_debug";
 				TARGETED_DEVICE_FAMILY = "$targeted_device_family";
 				VALID_ARCHS = "arm64 x86_64";
 				WRAPPER_EXTENSION = app;
@@ -374,6 +375,7 @@
 				MARKETING_VERSION = $short_version;
 				CURRENT_PROJECT_VERSION = $version;
 				PROVISIONING_PROFILE = "$provisioning_profile_uuid_release";
+				PROVISIONING_PROFILE_SPECIFIER = "$provisioning_profile_specifier_release";
 				TARGETED_DEVICE_FAMILY = "$targeted_device_family";
 				VALID_ARCHS = "arm64 x86_64";
 				WRAPPER_EXTENSION = app;

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -32,6 +32,14 @@
 		<member name="application/delete_old_export_files_unconditionally" type="bool" setter="" getter="">
 			If [code]true[/code], existing "project name" and "project name.xcodeproj" in the export destination directory will be unconditionally deleted during export.
 		</member>
+		<member name="application/provisioning_profile_specifier_debug" type="String" setter="" getter="">
+				Name of the provisioning profile. Sets XCode PROVISIONING_PROFILE_SPECIFIER for debug. https://developer.apple.com/documentation/xcode/build-settings-reference#Provisioning-Profile Used for manual provisioning.
+				Can be overridden with the environment variable [code]GODOT_IOS_PROFILE_SPECIFIER_DEBUG[/code].
+		</member>
+		<member name="application/provisioning_profile_specifier_release" type="String" setter="" getter="">
+				Name of the provisioning profile. Sets XCode PROVISIONING_PROFILE_SPECIFIER for release. https://developer.apple.com/documentation/xcode/build-settings-reference#Provisioning-Profile Used for manual provisioning.
+				Can be overridden with the environment variable [code]GODOT_IOS_PROFILE_SPECIFIER_RELEASE[/code].
+		</member>
 		<member name="application/export_method_debug" type="int" setter="" getter="">
 			Application distribution target (debug export).
 		</member>

--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -32,14 +32,6 @@
 		<member name="application/delete_old_export_files_unconditionally" type="bool" setter="" getter="">
 			If [code]true[/code], existing "project name" and "project name.xcodeproj" in the export destination directory will be unconditionally deleted during export.
 		</member>
-		<member name="application/provisioning_profile_specifier_debug" type="String" setter="" getter="">
-				Name of the provisioning profile. Sets XCode PROVISIONING_PROFILE_SPECIFIER for debug. https://developer.apple.com/documentation/xcode/build-settings-reference#Provisioning-Profile Used for manual provisioning.
-				Can be overridden with the environment variable [code]GODOT_IOS_PROFILE_SPECIFIER_DEBUG[/code].
-		</member>
-		<member name="application/provisioning_profile_specifier_release" type="String" setter="" getter="">
-				Name of the provisioning profile. Sets XCode PROVISIONING_PROFILE_SPECIFIER for release. https://developer.apple.com/documentation/xcode/build-settings-reference#Provisioning-Profile Used for manual provisioning.
-				Can be overridden with the environment variable [code]GODOT_IOS_PROFILE_SPECIFIER_RELEASE[/code].
-		</member>
 		<member name="application/export_method_debug" type="int" setter="" getter="">
 			Application distribution target (debug export).
 		</member>
@@ -57,6 +49,14 @@
 		</member>
 		<member name="application/min_ios_version" type="String" setter="" getter="">
 			Minimum version of iOS required for this application to run in the [code]major.minor.patch[/code] or [code]major.minor[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]).
+		</member>
+		<member name="application/provisioning_profile_specifier_debug" type="String" setter="" getter="">
+			Name of the provisioning profile. Sets XCode PROVISIONING_PROFILE_SPECIFIER for debug. https://developer.apple.com/documentation/xcode/build-settings-reference#Provisioning-Profile Used for manual provisioning.
+				Can be overridden with the environment variable [code]GODOT_IOS_PROFILE_SPECIFIER_DEBUG[/code].
+		</member>
+		<member name="application/provisioning_profile_specifier_release" type="String" setter="" getter="">
+			Name of the provisioning profile. Sets XCode PROVISIONING_PROFILE_SPECIFIER for release. https://developer.apple.com/documentation/xcode/build-settings-reference#Provisioning-Profile Used for manual provisioning.
+				Can be overridden with the environment variable [code]GODOT_IOS_PROFILE_SPECIFIER_RELEASE[/code].
 		</member>
 		<member name="application/provisioning_profile_uuid_debug" type="String" setter="" getter="">
 			UUID of the provisioning profile. If left empty, Xcode will download or create a provisioning profile automatically. See [url=https://developer.apple.com/help/account/manage-profiles/edit-download-or-delete-profiles]Edit, download, or delete provisioning profiles[/url].

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -451,7 +451,6 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 			String specifier = provisioning_profile_specifier_rel_variant.get_type() != Variant::NIL ? provisioning_profile_specifier_rel_variant : "";
 			strnew += lines[i].replace("$provisioning_profile_specifier_release", specifier) + "\n";
 		} else if (lines[i].contains("$provisioning_profile_specifier")) {
-			bool valid = p_debug ? valid_dbg_specifier : valid_rel_specifier;
 			String specifier = p_debug ? provisioning_profile_specifier_dbg_variant : provisioning_profile_specifier_rel_variant;
 			strnew += lines[i].replace("$provisioning_profile_specifier", specifier) + "\n";
 		} else if (lines[i].contains("$provisioning_profile_uuid_release")) {

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -2628,7 +2628,7 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 
 		print_line("xcodebuild (.ipa):\n" + export_str);
 		if (!export_str.contains("** EXPORT SUCCEEDED **")) {
-			add_message(EXPORT_MESSAGE_ERROR, TTR("Xcode Build"), vformat(TTR(".ipa export failed, see editor log for details. Log: %s"), export_str));
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Xcode Build"), TTR(".ipa export failed, see editor log for details."));
 			return FAILED;
 		}
 	}

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -268,11 +268,13 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/app_store_team_id"), "", false, true));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_uuid_debug", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SECRET), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/code_sign_identity_debug", PROPERTY_HINT_PLACEHOLDER_TEXT, "iPhone Developer"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_method_debug", PROPERTY_HINT_ENUM, "App Store,Development,Ad-Hoc,Enterprise"), 1));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_uuid_release", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SECRET), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/code_sign_identity_debug", PROPERTY_HINT_PLACEHOLDER_TEXT, "iPhone Developer"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/code_sign_identity_release", PROPERTY_HINT_PLACEHOLDER_TEXT, "iPhone Distribution"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_uuid_debug", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SECRET), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_uuid_release", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_SECRET), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_specifier_debug", PROPERTY_HINT_PLACEHOLDER_TEXT, ""), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_specifier_release", PROPERTY_HINT_PLACEHOLDER_TEXT, ""), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_method_release", PROPERTY_HINT_ENUM, "App Store,Development,Ad-Hoc,Enterprise"), 0));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/targeted_device_family", PROPERTY_HINT_ENUM, "iPhone,iPad,iPhone & iPad"), 2));
@@ -399,6 +401,15 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 	String rel_sign_id = p_preset->get("application/code_sign_identity_release").operator String().is_empty() ? "iPhone Distribution" : p_preset->get("application/code_sign_identity_release");
 	bool dbg_manual = !p_preset->get_or_env("application/provisioning_profile_uuid_debug", ENV_IOS_PROFILE_UUID_DEBUG).operator String().is_empty() || (dbg_sign_id != "iPhone Developer" && dbg_sign_id != "iPhone Distribution");
 	bool rel_manual = !p_preset->get_or_env("application/provisioning_profile_uuid_release", ENV_IOS_PROFILE_UUID_RELEASE).operator String().is_empty() || (rel_sign_id != "iPhone Developer" && rel_sign_id != "iPhone Distribution");
+
+	bool valid_dbg_specifier = false;
+	bool valid_rel_specifier = false;
+	Variant provisioning_profile_specifier_dbg_variant = p_preset->get_or_env("application/provisioning_profile_specifier_debug", ENV_IOS_PROFILE_SPECIFIER_DEBUG, &valid_dbg_specifier);
+	dbg_manual |= valid_dbg_specifier;
+
+	Variant provisioning_profile_specifier_rel_variant = p_preset->get_or_env("application/provisioning_profile_specifier_release", ENV_IOS_PROFILE_SPECIFIER_RELEASE, &valid_rel_specifier);
+	rel_manual |= valid_rel_specifier;
+
 	String str;
 	String strnew;
 	str.parse_utf8((const char *)pfile.ptr(), pfile.size());
@@ -433,6 +444,26 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].contains("$export_method")) {
 			int export_method = p_preset->get(p_debug ? "application/export_method_debug" : "application/export_method_release");
 			strnew += lines[i].replace("$export_method", export_method_string[export_method]) + "\n";
+		} else if (lines[i].contains("$provisioning_profile_specifier_debug")) {
+			String specifier = provisioning_profile_specifier_dbg_variant.get_type() != Variant::NIL ? provisioning_profile_specifier_dbg_variant : "";
+			strnew += lines[i].replace("$provisioning_profile_specifier_debug", specifier) + "\n";
+			if (valid_dbg_specifier == false) {
+				add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat("application/provisioning_profile_specifier_debug not found in export_presets"));
+			}
+		} else if (lines[i].contains("$provisioning_profile_specifier_release")) {
+			String specifier = provisioning_profile_specifier_rel_variant.get_type() != Variant::NIL ? provisioning_profile_specifier_rel_variant : "";
+			strnew += lines[i].replace("$provisioning_profile_specifier_release", specifier) + "\n";
+			if (valid_rel_specifier == false) {
+				add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat("application/provisioning_profile_specifier_release not found in export_presets"));
+			}
+		} else if (lines[i].contains("$provisioning_profile_specifier")) {
+			bool valid = p_debug ? valid_dbg_specifier : valid_rel_specifier;
+			if (valid == false) {
+				add_message(EXPORT_MESSAGE_WARNING, TTR("Export"),
+						p_debug ? vformat("application/provisioning_profile_specifier_debug not found in export_presets") : vformat("application/provisioning_profile_specifier_release not found in export_presets"));
+			}
+			String specifier = p_debug ? provisioning_profile_specifier_dbg_variant : provisioning_profile_specifier_rel_variant;
+			strnew += lines[i].replace("$provisioning_profile_specifier", specifier) + "\n";
 		} else if (lines[i].contains("$provisioning_profile_uuid_release")) {
 			strnew += lines[i].replace("$provisioning_profile_uuid_release", p_preset->get_or_env("application/provisioning_profile_uuid_release", ENV_IOS_PROFILE_UUID_RELEASE)) + "\n";
 		} else if (lines[i].contains("$provisioning_profile_uuid_debug")) {
@@ -450,7 +481,13 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 				strnew += lines[i].replace("$code_sign_style_release", "Automatic") + "\n";
 			}
 		} else if (lines[i].contains("$provisioning_profile_uuid")) {
-			String uuid = p_debug ? p_preset->get_or_env("application/provisioning_profile_uuid_debug", ENV_IOS_PROFILE_UUID_DEBUG) : p_preset->get_or_env("application/provisioning_profile_uuid_release", ENV_IOS_PROFILE_UUID_RELEASE);
+			bool valid = false;
+			String uuid = p_debug ? p_preset->get_or_env("application/provisioning_profile_uuid_debug", ENV_IOS_PROFILE_UUID_DEBUG, &valid) : p_preset->get_or_env("application/provisioning_profile_uuid_release", ENV_IOS_PROFILE_UUID_RELEASE, &valid);
+			if (valid == false || uuid.is_empty()) {
+				Variant variant = p_debug ? provisioning_profile_specifier_dbg_variant : provisioning_profile_specifier_rel_variant;
+				valid = p_debug ? valid_dbg_specifier : valid_rel_specifier;
+				uuid = valid ? variant : "";
+			}
 			strnew += lines[i].replace("$provisioning_profile_uuid", uuid) + "\n";
 		} else if (lines[i].contains("$code_sign_identity_debug")) {
 			strnew += lines[i].replace("$code_sign_identity_debug", dbg_sign_id) + "\n";
@@ -2591,7 +2628,7 @@ Error EditorExportPlatformIOS::_export_project_helper(const Ref<EditorExportPres
 
 		print_line("xcodebuild (.ipa):\n" + export_str);
 		if (!export_str.contains("** EXPORT SUCCEEDED **")) {
-			add_message(EXPORT_MESSAGE_ERROR, TTR("Xcode Build"), TTR(".ipa export failed, see editor log for details."));
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Xcode Build"), vformat(TTR(".ipa export failed, see editor log for details. Log: %s"), export_str));
 			return FAILED;
 		}
 	}

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -447,21 +447,11 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].contains("$provisioning_profile_specifier_debug")) {
 			String specifier = provisioning_profile_specifier_dbg_variant.get_type() != Variant::NIL ? provisioning_profile_specifier_dbg_variant : "";
 			strnew += lines[i].replace("$provisioning_profile_specifier_debug", specifier) + "\n";
-			if (valid_dbg_specifier == false) {
-				add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat("application/provisioning_profile_specifier_debug not found in export_presets"));
-			}
 		} else if (lines[i].contains("$provisioning_profile_specifier_release")) {
 			String specifier = provisioning_profile_specifier_rel_variant.get_type() != Variant::NIL ? provisioning_profile_specifier_rel_variant : "";
 			strnew += lines[i].replace("$provisioning_profile_specifier_release", specifier) + "\n";
-			if (valid_rel_specifier == false) {
-				add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat("application/provisioning_profile_specifier_release not found in export_presets"));
-			}
 		} else if (lines[i].contains("$provisioning_profile_specifier")) {
 			bool valid = p_debug ? valid_dbg_specifier : valid_rel_specifier;
-			if (valid == false) {
-				add_message(EXPORT_MESSAGE_WARNING, TTR("Export"),
-						p_debug ? vformat("application/provisioning_profile_specifier_debug not found in export_presets") : vformat("application/provisioning_profile_specifier_release not found in export_presets"));
-			}
 			String specifier = p_debug ? provisioning_profile_specifier_dbg_variant : provisioning_profile_specifier_rel_variant;
 			strnew += lines[i].replace("$provisioning_profile_specifier", specifier) + "\n";
 		} else if (lines[i].contains("$provisioning_profile_uuid_release")) {

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -54,6 +54,8 @@
 // of these is set, they will override the values set in the credentials file.
 const String ENV_IOS_PROFILE_UUID_DEBUG = "GODOT_IOS_PROVISIONING_PROFILE_UUID_DEBUG";
 const String ENV_IOS_PROFILE_UUID_RELEASE = "GODOT_IOS_PROVISIONING_PROFILE_UUID_RELEASE";
+const String ENV_IOS_PROFILE_SPECIFIER_DEBUG = "GODOT_IOS_PROFILE_SPECIFIER_DEBUG";
+const String ENV_IOS_PROFILE_SPECIFIER_RELEASE = "GODOT_IOS_PROFILE_SPECIFIER_RELEASE";
 
 class EditorExportPlatformIOS : public EditorExportPlatform {
 	GDCLASS(EditorExportPlatformIOS, EditorExportPlatform);


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode/build-settings-reference\#Provisioning-Profile

Used to allow for specific provisioning profile to be specified by name instead of UUID.

Needed to solve this problem where uuid wasn’t disambiguating: https://stackoverflow.com/questions/45051712/signing-app-with-xcodebuild-command-line-with-provisioning-profile-fails

Allows for specification for release and debug versions through environment variables or through export template attributes.

Debug:
EnvironmentVariable: GODOT_IOS_PROFILE_SPECIFIER_DEBUG Export template: “application/provisioning_profile_specifier_debug”

Release:
EnvironmentalVariable: GODOT_IOS_PROFILE_SPECIFIER_RELEASE Export Template: “application/provisioning_profile_specifier_release”

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
