### PR TITLE
DotnetFinder now uses DOTNET_ROOT and hostfxr_resolver will read from editor settings for which dotnet executable to use.

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -20,12 +20,12 @@ namespace GodotTools.Build
         private static Process LaunchBuild(BuildInfo buildInfo, Action<string?>? stdOutHandler,
             Action<string?>? stdErrHandler)
         {
-            string? dotnetPath = DotNetFinder.FindDotNetExe();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
+
+            string? dotnetPath = DotNetFinder.FindDotNetExe(editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable).As<string>());
 
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
-
-            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             var startInfo = new ProcessStartInfo(dotnetPath);
 
@@ -91,12 +91,12 @@ namespace GodotTools.Build
         private static Process LaunchPublish(BuildInfo buildInfo, Action<string?>? stdOutHandler,
             Action<string?>? stdErrHandler)
         {
-            string? dotnetPath = DotNetFinder.FindDotNetExe();
+            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
+
+            string? dotnetPath = DotNetFinder.FindDotNetExe(editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable).As<string>());
 
             if (dotnetPath == null)
                 throw new FileNotFoundException("Cannot find the dotnet executable.");
-
-            var editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             var startInfo = new ProcessStartInfo(dotnetPath);
 

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -34,6 +34,7 @@ namespace GodotTools
             public const string NoConsoleLogging = "dotnet/build/no_console_logging";
             public const string CreateBinaryLog = "dotnet/build/create_binary_log";
             public const string ProblemsLayout = "dotnet/build/problems_layout";
+            public const string OverrideDotnetExecutable = "dotnet/build/override_dotnet_executable";
         }
 
 #nullable disable
@@ -264,8 +265,7 @@ namespace GodotTools
                         GodotSharpDirs.ProjectSlnPath,
                         line >= 0 ? $"{scriptPath};{line + 1};{col + 1}" : scriptPath
                     };
-
-                    string command = DotNetFinder.FindDotNetExe() ?? "dotnet";
+                    string command = DotNetFinder.FindDotNetExe(_editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable).As<string>()) ?? "dotnet";
 
                     try
                     {
@@ -456,9 +456,14 @@ namespace GodotTools
 
             var dotNetSdkSearchVersion = Environment.Version;
 
+            _editorSettings = EditorInterface.Singleton.GetEditorSettings();
+
+            string? dotnetExecutableEditorSettings = _editorSettings.GetSetting(GodotSharpEditor.Settings.OverrideDotnetExecutable)
+                .As<string>();
+
             // First we try to find the .NET Sdk ourselves to make sure we get the
             // correct version first, otherwise pick the latest.
-            if (DotNetFinder.TryFindDotNetSdk(dotNetSdkSearchVersion, out var sdkVersion, out string? sdkPath))
+            if (DotNetFinder.TryFindDotNetSdk(dotNetSdkSearchVersion, dotnetExecutableEditorSettings, out var sdkVersion, out string? sdkPath))
             {
                 if (Godot.OS.IsStdOutVerbose())
                     Console.WriteLine($"Found .NET Sdk version '{sdkVersion}': {sdkPath}");
@@ -482,8 +487,6 @@ namespace GodotTools
             }
 
             var editorBaseControl = EditorInterface.Singleton.GetBaseControl();
-
-            _editorSettings = EditorInterface.Singleton.GetEditorSettings();
 
             _errorDialog = new AcceptDialog();
             _errorDialog.SetUnparentWhenInvisible(true);
@@ -542,6 +545,7 @@ namespace GodotTools
             EditorDef(Settings.VerbosityLevel, Variant.From(VerbosityLevelId.Normal));
             EditorDef(Settings.NoConsoleLogging, false);
             EditorDef(Settings.CreateBinaryLog, false);
+            EditorDef(Settings.OverrideDotnetExecutable, "");
             EditorDef(Settings.ProblemsLayout, Variant.From(BuildProblemsView.ProblemsLayout.Tree));
 
             string settingsHintStr = "Disabled";


### PR DESCRIPTION
hostfxr_resolver.cpp was already supporting the enviroment variable lookup for the dotnet executable (though it has the more specific and extensive architecture lookup as well, I only implemented the base version), so I brought that functionality to the c# side which is [one of the existing c# convention for how to get which dotnet version to use](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#net-sdk-and-cli-environment-variables).

While discussing the issue with @raulsntos, they proposed there were some cases on mac that would be issues with using environment variables (I'm building the editor myself, so I dont have the sandbox issue) and that there was a separate proposal to use a editor settings for the same purpose. Since I could see how that would be useful and replace my use case, I'm implemented that version as well.

Fixes Issue: https://github.com/godotengine/godot/issues/97501
Implements Proposal: https://github.com/godotengine/godot-proposals/issues/1941

Let me know if the editor settings should be named differently or I need to expand the environment variables lookups to be the more specific lookups based on architecture to get this into the engine.